### PR TITLE
Update tests_php

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -98,6 +98,10 @@
                 ${ROOTDIR}etc/php/7.3/fpm/php.ini \
                 ${ROOTDIR}etc/php/7.4/cli/php.ini \
                 ${ROOTDIR}etc/php/7.4/fpm/php.ini \
+                ${ROOTDIR}etc/php/8.0/cli/php.ini \
+                ${ROOTDIR}etc/php/8.0/fpm/php.ini \
+                ${ROOTDIR}etc/php/8.1/cli/php.ini \
+                ${ROOTDIR}etc/php/8.1/fpm/php.ini \
                 ${ROOTDIR}var/www/conf/php.ini \
                 ${ROOTDIR}usr/local/etc/php.ini \
                 ${ROOTDIR}usr/local/lib/php.ini \
@@ -152,11 +156,15 @@
                 ${ROOTDIR}etc/php/7.2/cli/conf.d \
                 ${ROOTDIR}etc/php/7.3/cli/conf.d \
                 ${ROOTDIR}etc/php/7.4/cli/conf.d \
+                ${ROOTDIR}etc/php/8.0/cli/conf.d \
+                ${ROOTDIR}etc/php/8.1/cli/conf.d \
                 ${ROOTDIR}etc/php/7.0/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.1/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.2/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.3/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.4/fpm/conf.d \
+                ${ROOTDIR}etc/php/8.0/fpm/conf.d \
+                ${ROOTDIR}etc/php/8.1/fpm/conf.d \
                 ${ROOTDIR}etc/php.d \
                 ${ROOTDIR}opt/cpanel/ea-php54/root/etc/php.d \
                 ${ROOTDIR}opt/cpanel/ea-php55/root/etc/php.d \


### PR DESCRIPTION
Add PHP versions 8.0 and 8.1 for Ubuntu 22.04